### PR TITLE
Request to Consider Renaming GitHub Username 'dohu'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,9 @@ The `app` generator will produce an `elements.html` file where you can place you
 
 See the [contributing docs](https://github.com/yeoman/yeoman/blob/master/contributing.md)
 
+
+
+
 When submitting an issue, please follow the [guidelines](https://github.com/yeoman/yeoman/blob/master/contributing.md#issue-submission). Especially important is to make sure Yeoman is up-to-date, and providing the command or commands that cause the issue.
 
 ## License


### PR DESCRIPTION
Hi @dohu ,

I hope you're doing well. My name is Marius Furtuna, and I’m an Engineering Manager at a company called Dohu (https://www.linkedin.com/company/dohu-consulting). I’m reaching out with a bit of an unusual request and would greatly appreciate your consideration.

Our team is in the process of migrating several JavaScript repositories from GitLab to GitHub, and we’re pushing packages to the GitHub npm registry. However, we've run into a bit of a challenge: in order to keep our package names in the format @dohu/package_name, we need to have a GitHub organization with the name "dohu," which is currently your username.

Since this was the only way I could reach you, I’ve forked your generator-polymer repository to open this pull request. I was wondering if you'd be open to considering changing your username to free up "dohu" for our organization. It would really help us avoid refactoring our package references, which would be a significant task given that some are already in production.

Thank you in advance for your time, and I look forward to hearing from you.

